### PR TITLE
Making sumcheck work with challenges

### DIFF
--- a/cpp/src/aztec/honk/proof_system/prover.cpp
+++ b/cpp/src/aztec/honk/proof_system/prover.cpp
@@ -295,7 +295,7 @@ template <typename settings> void Prover<settings>::execute_relation_check_round
     using Sumcheck = sumcheck::Sumcheck<Multivariates,
                                         Transcript,
                                         sumcheck::ArithmeticRelation,
-                                        // sumcheck::GrandProductComputationRelation,
+                                        sumcheck::GrandProductComputationRelation,
                                         sumcheck::GrandProductInitializationRelation>;
 
     // Compute alpha challenge

--- a/cpp/src/aztec/honk/proof_system/verifier.cpp
+++ b/cpp/src/aztec/honk/proof_system/verifier.cpp
@@ -135,7 +135,7 @@ template <typename program_settings> bool Verifier<program_settings>::verify_pro
     auto sumcheck = Sumcheck<Multivariates,
                              Transcript,
                              ArithmeticRelation,
-                             //  GrandProductComputationRelation,
+                             GrandProductComputationRelation,
                              GrandProductInitializationRelation>(transcript);
     bool sumcheck_result = sumcheck.execute_verifier();
 

--- a/cpp/src/aztec/honk/sumcheck/relations/arithmetic_relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/arithmetic_relation.hpp
@@ -28,7 +28,7 @@ template <typename FF> class ArithmeticRelation : public Relation<FF> {
      * @param extended_edges Contain inputs for the relation
      * @param evals Contains the resulting univariate polynomial
      */
-    void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals)
+    template <typename T> void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals, T)
     {
         add_edge_contribution_internal(extended_edges, evals);
     };
@@ -70,7 +70,8 @@ template <typename FF> class ArithmeticRelation : public Relation<FF> {
         evals += q_c;
     };
 
-    void add_full_relation_value_contribution(auto& purported_evaluations, FF& full_honk_relation_value)
+    template <typename T>
+    void add_full_relation_value_contribution(auto& purported_evaluations, FF& full_honk_relation_value, T)
     {
         auto w_l = purported_evaluations[MULTIVARIATE::W_L];
         auto w_r = purported_evaluations[MULTIVARIATE::W_R];

--- a/cpp/src/aztec/honk/sumcheck/relations/grand_product_initialization_relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/grand_product_initialization_relation.hpp
@@ -22,7 +22,7 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
      *
      *                      C(X) = L_LAST(X) * Z_perm_shift(X)
      */
-    void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals)
+    template <typename T> void add_edge_contribution(auto& extended_edges, Univariate<FF, RELATION_LENGTH>& evals, T)
     {
         add_edge_contribution_internal(extended_edges, evals);
     };
@@ -55,7 +55,8 @@ template <typename FF> class GrandProductInitializationRelation : public Relatio
         add_edge_contribution_internal(extended_edges, evals);
     }
 
-    void add_full_relation_value_contribution(auto& purported_evaluations, FF& full_honk_relation_value)
+    template <typename T>
+    void add_full_relation_value_contribution(auto& purported_evaluations, FF& full_honk_relation_value, T)
     {
         auto z_perm_shift = purported_evaluations[MULTIVARIATE::Z_PERM_SHIFT];
         auto lagrange_last = purported_evaluations[MULTIVARIATE::LAGRANGE_LAST];

--- a/cpp/src/aztec/honk/sumcheck/relations/relation.hpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/relation.hpp
@@ -4,4 +4,10 @@ namespace honk::sumcheck {
 
 template <typename Fr> class Relation {}; // TODO(Cody): Use or eventually remove.
 
+template <typename FF> struct RelationParameters {
+    FF alpha;
+    FF beta;
+    FF gamma;
+    FF public_input_delta;
+};
 } // namespace honk::sumcheck

--- a/cpp/src/aztec/honk/sumcheck/relations/relation.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/relations/relation.test.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(SumcheckRelation, ArithmeticRelation)
     Univariate expected_evals = (q_m * w_r * w_l) + (q_r * w_r) + (q_l * w_l) + (q_o * w_o) + (q_c);
 
     auto evals = Univariate<FF, relation.RELATION_LENGTH>();
-    relation.add_edge_contribution(extended_edges, evals);
+    relation.add_edge_contribution(extended_edges, evals, 0);
 
     EXPECT_EQ(evals, expected_evals);
 };
@@ -120,9 +120,12 @@ TYPED_TEST(SumcheckRelation, GrandProductComputationRelation)
     auto lagrange_first = UnivariateView(extended_edges[MULTIVARIATE::LAGRANGE_FIRST]);
     auto lagrange_last = UnivariateView(extended_edges[MULTIVARIATE::LAGRANGE_LAST]);
     // TODO(luke): use real transcript/challenges once manifest is done
-    FF beta = FF::one();
-    FF gamma = FF::one();
-    FF public_input_delta = FF::one();
+    FF beta = FF::random_element();
+    FF gamma = FF::random_element();
+    FF public_input_delta = FF::random_element();
+    const RelationParameters<FF> relation_parameters = RelationParameters<FF>{
+        .alpha = FF ::zero(), .beta = beta, .gamma = gamma, .public_input_delta = public_input_delta
+    };
 
     auto expected_evals = Univariate();
     // expected_evals in the below step { { 27, 250, 1029, 2916, 6655 } }
@@ -133,7 +136,7 @@ TYPED_TEST(SumcheckRelation, GrandProductComputationRelation)
                       (w_2 + sigma_2 * beta + gamma) * (w_3 + sigma_3 * beta + gamma);
 
     auto evals = Univariate();
-    relation.add_edge_contribution(extended_edges, evals);
+    relation.add_edge_contribution(extended_edges, evals, relation_parameters);
 
     EXPECT_EQ(evals, expected_evals);
 };
@@ -157,7 +160,7 @@ TYPED_TEST(SumcheckRelation, GrandProductInitializationRelation)
 
     // Compute the edge contribution using add_edge_contribution
     auto evals = Univariate();
-    relation.add_edge_contribution(extended_edges, evals);
+    relation.add_edge_contribution(extended_edges, evals, 0);
 
     EXPECT_EQ(evals, expected_evals);
 };

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "common/serialize.hpp"
 #include "proof_system/types/polynomial_manifest.hpp"
+#include <honk/utils/public_inputs.hpp>
 #include "common/throw_or_abort.hpp"
 #include "ecc/curves/bn254/fr.hpp"
 #include "sumcheck_round.hpp"
@@ -36,6 +37,34 @@ template <class Multivariates, class Transcript, template <class> class... Relat
         , round(std::tuple(Relations<FF>()...)){};
 
     /**
+     * @brief Get all the challenges and computed parameters used in sumcheck in a convenient format
+     *
+     * @return RelationParameters<FF>
+     */
+    RelationParameters<FF> retrieve_proof_parameters()
+    {
+        const FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
+        const FF beta = FF::serialize_from_buffer(transcript.get_challenge("beta").begin());
+        const FF gamma = FF::serialize_from_buffer(transcript.get_challenge("beta", 1).begin());
+        const auto public_input_size_vector = transcript.get_element("public_input_size");
+        const size_t public_input_size = (static_cast<size_t>(public_input_size_vector[0]) << 24) |
+                                         (static_cast<size_t>(public_input_size_vector[1]) << 16) |
+                                         (static_cast<size_t>(public_input_size_vector[2]) << 8) |
+
+                                         static_cast<size_t>(public_input_size_vector[3]);
+        const auto circut_size_vector = transcript.get_element("circuit_size");
+        const size_t n = (static_cast<size_t>(circut_size_vector[0]) << 24) |
+                         (static_cast<size_t>(circut_size_vector[1]) << 16) |
+                         (static_cast<size_t>(circut_size_vector[2]) << 8) | static_cast<size_t>(circut_size_vector[3]);
+        std::vector<FF> public_inputs = many_from_buffer<FF>(transcript.get_element("public_inputs"));
+        ASSERT(public_inputs.size() * sizeof(FF) == public_input_size);
+        FF public_input_delta = honk::compute_public_input_delta<FF>(public_inputs, beta, gamma, n);
+        const RelationParameters<FF> relation_parameters = RelationParameters<FF>{
+            .alpha = alpha, .beta = beta, .gamma = gamma, .public_input_delta = public_input_delta
+        };
+        return relation_parameters;
+    }
+    /**
      * @brief Compute univariate restriction place in transcript, generate challenge, fold,... repeat until final round,
      * then compute multivariate evaluations and place in transcript.
      *
@@ -45,8 +74,9 @@ template <class Multivariates, class Transcript, template <class> class... Relat
     {
         // First round
         // This populates multivariates.folded_polynomials.
-        FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
-        auto round_univariate = round.compute_univariate(multivariates.full_polynomials, alpha);
+
+        const auto relation_parameters = retrieve_proof_parameters();
+        auto round_univariate = round.compute_univariate(multivariates.full_polynomials, relation_parameters);
         info("Round univariate:", round_univariate);
         transcript.add_element("univariate_" + std::to_string(multivariates.multivariate_d),
                                round_univariate.to_buffer());
@@ -60,7 +90,7 @@ template <class Multivariates, class Transcript, template <class> class... Relat
         // We operate on multivariates.folded_polynomials in place.
         for (size_t round_idx = 1; round_idx < multivariates.multivariate_d; round_idx++) {
             // Write the round univariate to the transcript
-            round_univariate = round.compute_univariate(multivariates.folded_polynomials, alpha);
+            round_univariate = round.compute_univariate(multivariates.folded_polynomials, relation_parameters);
             transcript.add_element("univariate_" + std::to_string(multivariates.multivariate_d - round_idx),
                                    round_univariate.to_buffer());
             challenge_label = "u_" + std::to_string(multivariates.multivariate_d - round_idx);
@@ -103,6 +133,7 @@ template <class Multivariates, class Transcript, template <class> class... Relat
     {
         bool verified(true);
 
+        const auto relation_parameters = retrieve_proof_parameters();
         // All but final round.
         // target_total_sum is initialized to zero then mutated in place.
 
@@ -128,9 +159,8 @@ template <class Multivariates, class Transcript, template <class> class... Relat
 
         // Final round
         auto purported_evaluations = transcript.get_field_element_vector("multivariate_evaluations");
-        FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
         FF full_honk_relation_purported_value =
-            round.compute_full_honk_relation_purported_value(purported_evaluations, alpha);
+            round.compute_full_honk_relation_purported_value(purported_evaluations, relation_parameters);
         verified = verified && (full_honk_relation_purported_value == round.target_total_sum);
         return verified;
     };

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.hpp
@@ -47,6 +47,7 @@ template <class Multivariates, class Transcript, template <class> class... Relat
         // This populates multivariates.folded_polynomials.
         FF alpha = FF::serialize_from_buffer(transcript.get_challenge("alpha").begin());
         auto round_univariate = round.compute_univariate(multivariates.full_polynomials, alpha);
+        info("Round univariate:", round_univariate);
         transcript.add_element("univariate_" + std::to_string(multivariates.multivariate_d),
                                round_univariate.to_buffer());
         std::string challenge_label = "u_" + std::to_string(multivariates.multivariate_d);

--- a/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck.test.cpp
@@ -215,7 +215,7 @@ TEST(Sumcheck, ProverAndVerifier)
     const size_t multivariate_n(1 << multivariate_d);
     // const size_t max_relation_length = 5;
 
-    const size_t max_relation_length = 4 /* honk::StandardHonk::MAX_RELATION_LENGTH */;
+    const size_t max_relation_length = 5 /* honk::StandardHonk::MAX_RELATION_LENGTH */;
     constexpr size_t fr_size = 32;
 
     using Multivariates = ::Multivariates<FF, num_polys>;
@@ -277,7 +277,7 @@ TEST(Sumcheck, ProverAndVerifier)
     auto sumcheck_prover = Sumcheck<Multivariates,
                                     Transcript,
                                     ArithmeticRelation,
-                                    // GrandProductComputationRelation,
+                                    GrandProductComputationRelation,
                                     GrandProductInitializationRelation>(multivariates, transcript);
 
     sumcheck_prover.execute_prover();
@@ -285,7 +285,7 @@ TEST(Sumcheck, ProverAndVerifier)
     auto sumcheck_verifier = Sumcheck<Multivariates,
                                       Transcript,
                                       ArithmeticRelation,
-                                      //   GrandProductComputationRelation,
+                                      GrandProductComputationRelation,
                                       GrandProductInitializationRelation>(transcript);
 
     bool verified = sumcheck_verifier.execute_verifier();
@@ -300,7 +300,7 @@ TEST(Sumcheck, ProverAndVerifierLonger)
         const size_t multivariate_n(1 << multivariate_d);
         // const size_t max_relation_length = 5;
 
-        const size_t max_relation_length = 4 /* honk::StandardHonk::MAX_RELATION_LENGTH */;
+        const size_t max_relation_length = 5 /* honk::StandardHonk::MAX_RELATION_LENGTH */;
         constexpr size_t fr_size = 32;
 
         using Multivariates = ::Multivariates<FF, num_polys>;
@@ -368,7 +368,7 @@ TEST(Sumcheck, ProverAndVerifierLonger)
         auto sumcheck_prover = Sumcheck<Multivariates,
                                         Transcript,
                                         ArithmeticRelation,
-                                        // GrandProductComputationRelation,
+                                        GrandProductComputationRelation,
                                         GrandProductInitializationRelation>(multivariates, transcript);
 
         sumcheck_prover.execute_prover();
@@ -376,7 +376,7 @@ TEST(Sumcheck, ProverAndVerifierLonger)
         auto sumcheck_verifier = Sumcheck<Multivariates,
                                           Transcript,
                                           ArithmeticRelation,
-                                          //   GrandProductComputationRelation,
+                                          GrandProductComputationRelation,
                                           GrandProductInitializationRelation>(transcript);
 
         bool verified = sumcheck_verifier.execute_verifier();

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
@@ -141,6 +141,7 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
         for (size_t idx = 0; idx < num_multivariates; idx++) {
             auto edge = Univariate<FF, 2>({ multivariate[idx][edge_idx], multivariate[idx][edge_idx + 1] });
             extended_edges[idx] = barycentric_2_to_max.extend(edge);
+            info("idx: ", idx, " extended_edges: ", extended_edges[idx]);
         }
     }
 
@@ -246,7 +247,11 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
     {
         for (size_t edge_idx = 0; edge_idx < round_size; edge_idx += 2) {
             extend_edges(polynomials, edge_idx);
+
             accumulate_relation_univariates<>();
+            info("Arithmetic:", std::get<0>(univariate_accumulators));
+            info("Grand Product Computation:", std::get<1>(univariate_accumulators));
+            info("Grand Product Initialization:", std::get<2>(univariate_accumulators));
         }
 
         auto result = batch_over_relations<Univariate<FF, MAX_RELATION_LENGTH>>(relation_separator_challenge);

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.hpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include "polynomials/barycentric_data.hpp"
 #include "polynomials/univariate.hpp"
+#include "relations/relation.hpp"
 namespace honk::sumcheck {
 
 /*
@@ -141,7 +142,6 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
         for (size_t idx = 0; idx < num_multivariates; idx++) {
             auto edge = Univariate<FF, 2>({ multivariate[idx][edge_idx], multivariate[idx][edge_idx + 1] });
             extended_edges[idx] = barycentric_2_to_max.extend(edge);
-            info("idx: ", idx, " extended_edges: ", extended_edges[idx]);
         }
     }
 
@@ -187,14 +187,15 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
      * group of edges. These are stored in `univariate_accumulators`. Adding these univariates together, with
      * appropriate scaling factors, produces S_l.
      */
-    template <size_t relation_idx = 0> void accumulate_relation_univariates()
+    template <size_t relation_idx = 0>
+    void accumulate_relation_univariates(const RelationParameters<FF>& relation_parameters)
     {
-        std::get<relation_idx>(relations).add_edge_contribution(extended_edges,
-                                                                std::get<relation_idx>(univariate_accumulators));
+        std::get<relation_idx>(relations).add_edge_contribution(
+            extended_edges, std::get<relation_idx>(univariate_accumulators), relation_parameters);
 
         // Repeat for the next relation.
         if constexpr (relation_idx + 1 < NUM_RELATIONS) {
-            accumulate_relation_univariates<relation_idx + 1>();
+            accumulate_relation_univariates<relation_idx + 1>(relation_parameters);
         }
     }
 
@@ -210,14 +211,15 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
      */
     template <size_t relation_idx = 0>
     // TODO(Cody): Input should be an array? Then challenge container has to know array length.
-    void accumulate_relation_evaluations(std::vector<FF>& purported_evaluations)
+    void accumulate_relation_evaluations(std::vector<FF>& purported_evaluations,
+                                         const RelationParameters<FF>& relation_parameters)
     {
-        std::get<relation_idx>(relations).add_full_relation_value_contribution(purported_evaluations,
-                                                                               evaluations[relation_idx]);
+        std::get<relation_idx>(relations).add_full_relation_value_contribution(
+            purported_evaluations, evaluations[relation_idx], relation_parameters);
 
         // Repeat for the next relation.
         if constexpr (relation_idx + 1 < NUM_RELATIONS) {
-            accumulate_relation_evaluations<relation_idx + 1>(purported_evaluations);
+            accumulate_relation_evaluations<relation_idx + 1>(purported_evaluations, relation_parameters);
         }
     }
 
@@ -243,18 +245,19 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
      * values. Most likely this will end up being S_l(0), ... , S_l(t-1) where t is around 12. At the end, reset all
      * univariate accumulators to be zero.
      */
-    Univariate<FF, MAX_RELATION_LENGTH> compute_univariate(auto& polynomials, FF& relation_separator_challenge)
+    Univariate<FF, MAX_RELATION_LENGTH> compute_univariate(auto& polynomials,
+                                                           const RelationParameters<FF>& relation_parameters)
     {
         for (size_t edge_idx = 0; edge_idx < round_size; edge_idx += 2) {
             extend_edges(polynomials, edge_idx);
 
-            accumulate_relation_univariates<>();
+            accumulate_relation_univariates<>(relation_parameters);
             info("Arithmetic:", std::get<0>(univariate_accumulators));
             info("Grand Product Computation:", std::get<1>(univariate_accumulators));
             info("Grand Product Initialization:", std::get<2>(univariate_accumulators));
         }
 
-        auto result = batch_over_relations<Univariate<FF, MAX_RELATION_LENGTH>>(relation_separator_challenge);
+        auto result = batch_over_relations<Univariate<FF, MAX_RELATION_LENGTH>>(relation_parameters.alpha);
 
         reset_accumulators<>();
 
@@ -262,16 +265,16 @@ template <class FF, size_t num_multivariates, template <class> class... Relation
     }
 
     FF compute_full_honk_relation_purported_value(std::vector<FF>& purported_evaluations,
-                                                  FF& relation_separator_challenge)
+                                                  const RelationParameters<FF>& relation_parameters)
     {
-        accumulate_relation_evaluations<>(purported_evaluations);
+        accumulate_relation_evaluations<>(purported_evaluations, relation_parameters);
 
         // IMPROVEMENT(Cody): Reuse functions from univariate_accumulators batching?
         FF running_challenge = 1;
         FF output = 0;
         for (auto& evals : evaluations) {
             output += evals * running_challenge;
-            running_challenge *= relation_separator_challenge;
+            running_challenge *= relation_parameters.alpha;
         }
 
         return output;

--- a/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
+++ b/cpp/src/aztec/honk/sumcheck/sumcheck_round.test.cpp
@@ -62,9 +62,10 @@ TEST(SumcheckRound, ComputeUnivariateProver)
                                ArithmeticRelation,
                                GrandProductComputationRelation,
                                GrandProductInitializationRelation>(round_size, relations);
-    FF relation_separator_challenge = 1;
+    const RelationParameters<FF> relation_parameters =
+        RelationParameters<FF>{ .alpha = 1, .beta = 1, .gamma = 1, .public_input_delta = 1 };
     Univariate<FF, max_relation_length> round_univariate =
-        round.compute_univariate(full_polynomials, relation_separator_challenge);
+        round.compute_univariate(full_polynomials, relation_parameters);
     Univariate<FF, max_relation_length> expected_round_univariate{ { 32, 149, 406, 857, 1556 } };
 
     EXPECT_EQ(round_univariate, expected_round_univariate);
@@ -115,9 +116,10 @@ TEST(SumcheckRound, ComputeUnivariateVerifier)
                                ArithmeticRelation,
                                GrandProductComputationRelation,
                                GrandProductInitializationRelation>(relations);
-    FF relation_separator_challenge = -1;
+    const RelationParameters<FF> relation_parameters =
+        RelationParameters<FF>{ .alpha = -1, .beta = 1, .gamma = 1, .public_input_delta = 1 };
     FF full_purported_value =
-        round.compute_full_honk_relation_purported_value(purported_evaluations, relation_separator_challenge);
+        round.compute_full_honk_relation_purported_value(purported_evaluations, relation_parameters);
     EXPECT_EQ(full_purported_value, expected_full_purported_value);
 }
 

--- a/cpp/src/aztec/proof_system/flavor/flavor.hpp
+++ b/cpp/src/aztec/proof_system/flavor/flavor.hpp
@@ -40,7 +40,7 @@ struct StandardHonk {
     using MULTIVARIATE = Arithmetization::POLYNOMIAL;
     // // TODO(Cody): Where to specify? is this polynomial manifest size?
     // static constexpr size_t STANDARD_HONK_MANIFEST_SIZE = 16;
-    static constexpr size_t MAX_RELATION_LENGTH = 4; // TODO(Cody): increment after fixing add_edge_contribution; kill
+    static constexpr size_t MAX_RELATION_LENGTH = 5; // TODO(Cody): increment after fixing add_edge_contribution; kill
                                                      // after moving barycentric class out of relations
 
     // TODO(Cody): should extract this from the parameter pack. Maybe that should be done here?


### PR DESCRIPTION
Original author: Rumata888
**Copied from PR https://github.com/AztecProtocol/barretenberg/pull/87** with new branches that have git history restored
# Description
Fixes one more bug in the GP relation and adds using challenges to sumcheck.
# Checklist:

- [ ] I have reviewed my diff in github, line by line.
- [ ] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [ ] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [ ] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [ ] There are no circuit changes, OR a cryptographer has been assigned for review.
- [ ] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [ ] The branch has been rebased against the head of its merge target.
- [ ] I'm happy for the PR to be merged at the reviewer's next convenience.
- [ ] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [ ] If existing code has been modified, such documentation has been added or updated.
